### PR TITLE
Fix backslash bugs. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,17 @@
         "command": "snippet-creator.createSnippet",
         "title": "Snippet Creator: Create Snippet"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "SnippetCreator",
+      "properties": {
+        "snippet-creator.autoDescription": {
+          "type": "boolean",
+          "default": true,
+          "description": "Auto-generate description from prefix."
+        }
+      }
+    }
   },
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",

--- a/src/gatherSnippet.js
+++ b/src/gatherSnippet.js
@@ -16,9 +16,15 @@ async function gatherSnippet() {
     prompt: 'Enter snippet prefix'
   });
 
-  const description = await vscode.window.showInputBox({
-    prompt: 'Enter snippet description'
-  });
+  let description
+  if (vscode.workspace.getConfiguration().get("snippet-creator.autoDescription")) {
+    description = prefix
+  } else {
+    description = await vscode.window.showInputBox({
+      prompt: 'Enter snippet description'
+    });
+  }
+
 
   return {
     language: editor.document.languageId,

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,6 +14,9 @@ function sanitizePowershell(code) {
 }
 
 function cleanBody(code, languageId) {
+  // Because of the VSCode is compatible with TextMate.
+  // Backslash has some different behaviour.
+  code = code.replace("\\", "\\\\");
   if (languageId === 'powershell') {
     return sanitizePowershell(code.replace(/\t/g, '\\t'));
   } else {


### PR DESCRIPTION
VSCode has a code snippet backslash bug. This bug will cause backslash to vanish.

By the way, I had add one configure option to improve user experience. Sometimes I only want to quickly add a snippet and describe it by the prefix info. This option will be much helpful.